### PR TITLE
Creating a store for managing a global data state.

### DIFF
--- a/pwa/src/routes.tsx
+++ b/pwa/src/routes.tsx
@@ -24,20 +24,19 @@ const AppStack = createStackNavigator<AppStackParamList>()
 
 const Routes = () => {
     return (
-        <NavigationContainer>
-            <AppStack.Navigator headerMode='none'>
-                <AppStack.Screen name='Home' component={Home} />
-                <AppStack.Screen name='Login' component={Login} />
-                <AppStack.Screen name='Register' component={Register} />
+        <DataStateProvider>
+            <NavigationContainer>
+                <AppStack.Navigator headerMode='none'>
+                    <AppStack.Screen name='Home' component={Home} />
+                    <AppStack.Screen name='Login' component={Login} />
+                    <AppStack.Screen name='Register' component={Register} />
 
-                <DataStateProvider>
                     <AppStack.Screen name='Dashboard' component={Dashboard} />
                     <AppStack.Screen name='NewTransaction' component={NewTransaction} />
                     <AppStack.Screen name='Detail' component={Detail} />
-                </DataStateProvider>
-
-            </AppStack.Navigator>
-        </NavigationContainer>
+                </AppStack.Navigator>
+            </NavigationContainer>
+        </DataStateProvider>
     )
 }
 

--- a/pwa/src/routes.tsx
+++ b/pwa/src/routes.tsx
@@ -9,6 +9,8 @@ import Dashboard from './pages/Dashboard'
 import NewTransaction from './pages/NewTransaction'
 import Detail from './pages/Detail'
 
+import DataStateProvider from './store/DataStateProvider'
+
 export type AppStackParamList = {
     Home: undefined
     Login: undefined
@@ -27,9 +29,13 @@ const Routes = () => {
                 <AppStack.Screen name='Home' component={Home} />
                 <AppStack.Screen name='Login' component={Login} />
                 <AppStack.Screen name='Register' component={Register} />
-                <AppStack.Screen name='Dashboard' component={Dashboard} />
-                <AppStack.Screen name='NewTransaction' component={NewTransaction} />
-                <AppStack.Screen name='Detail' component={Detail} />
+
+                <DataStateProvider>
+                    <AppStack.Screen name='Dashboard' component={Dashboard} />
+                    <AppStack.Screen name='NewTransaction' component={NewTransaction} />
+                    <AppStack.Screen name='Detail' component={Detail} />
+                </DataStateProvider>
+
             </AppStack.Navigator>
         </NavigationContainer>
     )

--- a/pwa/src/store/DataStateProvider.tsx
+++ b/pwa/src/store/DataStateProvider.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import useDataState from './useDataState'
+import DataContext from './dataContext'
+
+const DataStateProvider: React.FC = ({ children }) => (
+    <DataContext.Provider value={useDataState()}>
+        {children}
+    </DataContext.Provider>
+)
+
+
+export default DataStateProvider

--- a/pwa/src/store/dataContext.ts
+++ b/pwa/src/store/dataContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react'
+import { DataStateContext } from './types'
+
+const DataContext = createContext<DataStateContext>({} as DataStateContext)
+
+export default DataContext

--- a/pwa/src/store/types.d.ts
+++ b/pwa/src/store/types.d.ts
@@ -1,0 +1,18 @@
+import React from 'react'
+import { StockInfo } from "../pages/Dashboard";
+import { YahooStock } from "../services/yahooFinance/stockInfo";
+
+export interface DataState {
+    stocksData: Map<string, StockInfo>
+    yahooData: Map<string, YahooStock>
+}
+
+export interface Action {
+    type: string
+    payload: Map<string, StockInfo | YahooStock>
+}
+
+export interface DataStateContext {
+    state: DataState
+    dispatch: React.Dispatch<Action>
+}

--- a/pwa/src/store/types.d.ts
+++ b/pwa/src/store/types.d.ts
@@ -4,7 +4,9 @@ import { YahooStock } from "../services/yahooFinance/stockInfo";
 
 export interface DataState {
     stocksData: Map<string, StockInfo>
+    isStocksDataReady: boolean
     yahooData: Map<string, YahooStock>
+    isYahooDataReady: boolean
 }
 
 export interface Action {

--- a/pwa/src/store/types.d.ts
+++ b/pwa/src/store/types.d.ts
@@ -10,7 +10,7 @@ export interface DataState {
 }
 
 export interface Action {
-    type: string
+    type: 'SET_STOCKS' | 'SET_YAHOO'
     payload: Map<string, StockInfo | YahooStock>
 }
 

--- a/pwa/src/store/useDataState.ts
+++ b/pwa/src/store/useDataState.ts
@@ -1,0 +1,37 @@
+import { useReducer } from 'react'
+import { DataState, Action } from './types'
+import { StockInfo } from '../pages/Dashboard'
+import { YahooStock } from '../services/yahooFinance/stockInfo'
+
+
+const reducer = (state: DataState, action: Action): DataState => {
+    switch (action.type) {
+        case 'SET_STOCKS':
+            return {
+                ...state,
+                stocksData: action.payload as Map<string, StockInfo>
+            }
+        case 'SET_YAHOO':
+            return {
+                ...state,
+                yahooData: action.payload as Map<string, YahooStock>
+            }
+        default:
+            return {
+                ...state
+            }
+    }
+}
+
+const initialState = {
+    stocksData: new Map(),
+    yahooData: new Map(),
+}
+
+const useDataState = () => {
+    const [state, dispatch] = useReducer(reducer, initialState)
+
+    return { state, dispatch }
+}
+
+export default useDataState

--- a/pwa/src/store/useDataState.ts
+++ b/pwa/src/store/useDataState.ts
@@ -9,12 +9,15 @@ const reducer = (state: DataState, action: Action): DataState => {
         case 'SET_STOCKS':
             return {
                 ...state,
-                stocksData: action.payload as Map<string, StockInfo>
+                stocksData: action.payload as Map<string, StockInfo>,
+                isStocksDataReady: true,
+                isYahooDataReady: false,
             }
         case 'SET_YAHOO':
             return {
                 ...state,
-                yahooData: action.payload as Map<string, YahooStock>
+                yahooData: action.payload as Map<string, YahooStock>,
+                isYahooDataReady: true,
             }
         default:
             return {
@@ -25,7 +28,9 @@ const reducer = (state: DataState, action: Action): DataState => {
 
 const initialState = {
     stocksData: new Map(),
+    isStocksDataReady: false,
     yahooData: new Map(),
+    isYahooDataReady: false,
 }
 
 const useDataState = () => {


### PR DESCRIPTION
Instead of managing the Dashboard screen's isolated data state, it would be more flexible to manage the data access globally for the entire application.

Right now, the backend stock data and the Yahoo Finance external data are being managed only inside the Dashboard screen when it renders. This makes it difficult to have an updating action be executed whenever a new transaction is created on the NewTransaction screen, for example.

Using a global state, actions that modify it can be called from any screen, not just when the Dashboard is on focus.

This will also make future UX changes possible and easier to implement. These changes could include pre-loading the data when a new transaction is created in NewTransaction for faster rendering of the Dashboard, or sharing part of the data between Dashboard and Detail screens. Both of these significantly reduce the load-screen time the user experiences.