### PR TITLE
Prerender dashboard

### DIFF
--- a/pwa/src/pages/Dashboard/components/StockList.tsx
+++ b/pwa/src/pages/Dashboard/components/StockList.tsx
@@ -1,17 +1,16 @@
-import React from 'react'
+import React, { useContext, useMemo } from 'react'
 import { StyleSheet, Text, View, TouchableOpacity, Dimensions, FlatList } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
 
 import { Stock } from '../../../services/api/types'
 import { YahooStock } from '../../../services/yahooFinance/stockInfo'
+import DataContext from '../../../store/dataContext'
 
 
-interface Props {
-    stocksData: Map<string, Stock>
-    yahooData: Map<string, YahooStock>
-}
+const StockList = () => {
+    const { state } = useContext(DataContext)
+    const { stocksData, yahooData, isYahooDataReady } = state
 
-const StockList: React.FC<Props> = ({ stocksData, yahooData }) => {
     const navigation = useNavigation()
 
     const stocksList = Array.from(stocksData.values())
@@ -27,21 +26,53 @@ const StockList: React.FC<Props> = ({ stocksData, yahooData }) => {
             renderItem={({ item }: { item: Stock }) => {
                 const { ticker, currently_owned_shares, average_bought_price } = item
 
-                const { regularMarketPrice } = yahooData.get(ticker) as YahooStock
-
-                const potentialProfit = (regularMarketPrice - average_bought_price) * currently_owned_shares
-                const profitColor = potentialProfit > 0 ? '#0a0' : '#d00'
-
                 return (
                     <TouchableOpacity onPress={() => navigateToDetail(item)}>
                         <View style={styles.tickerContainer}>
                             <Text style={{ fontSize: 18, fontWeight: 'bold' }}>{ticker}</Text>
                         </View>
+
                         <View style={styles.gridRow}>
-                            <View style={styles.gridColumn}><Text>x{currently_owned_shares}</Text></View>
-                            <View style={styles.gridColumn}><Text>{average_bought_price.toFixed(2)}</Text></View>
-                            <View style={styles.gridColumn}><Text>{regularMarketPrice.toFixed(2)}</Text></View>
-                            <View style={styles.gridColumn}><Text style={{ color: profitColor }}>{potentialProfit.toFixed(2)}</Text></View>
+
+                            <View style={styles.gridColumn}>
+                                <Text>x{currently_owned_shares}</Text>
+                            </View>
+
+                            <View style={styles.gridColumn}>
+                                <Text>{average_bought_price.toFixed(2)}</Text>
+                            </View>
+
+                            {useMemo(() => {
+                                if (!isYahooDataReady) {
+                                    return (
+                                        <>
+                                            <View style={styles.gridColumn}>
+                                                <Text>-</Text>
+                                            </View>
+                                            <View style={styles.gridColumn}>
+                                                <Text>-</Text>
+                                            </View>
+                                        </>
+                                    )
+                                }
+
+                                const { regularMarketPrice } = yahooData.get(ticker) as YahooStock
+
+                                const potentialProfit = (regularMarketPrice - average_bought_price) * currently_owned_shares
+                                const profitColor = potentialProfit > 0 ? '#0a0' : '#d00'
+
+                                return (
+                                    <>
+                                        <View style={styles.gridColumn}>
+                                            <Text>{regularMarketPrice.toFixed(2)}</Text>
+                                        </View>
+                                        <View style={styles.gridColumn}>
+                                            <Text style={{ color: profitColor }}>{potentialProfit.toFixed(2)}</Text>
+                                        </View>
+                                    </>
+                                )
+                            }, [isYahooDataReady, yahooData, ticker])}
+
                         </View>
                     </TouchableOpacity>
                 )

--- a/pwa/src/pages/Dashboard/index.tsx
+++ b/pwa/src/pages/Dashboard/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import { StyleSheet, SafeAreaView, Platform, View, Text } from 'react-native'
-import { AppLoading } from 'expo'
 import { useNavigation } from '@react-navigation/native'
 import { Feather as Icon } from '@expo/vector-icons'
 import ActionButton from 'react-native-action-button'
@@ -33,20 +32,14 @@ const Dashboard = () => {
         }
     }, [isStocksDataReady, isYahooDataReady, stocksData], 30 * 1000, false)
 
-    if (!isStocksDataReady || !isYahooDataReady) {
-        return <AppLoading />
-    }
-
     return (
         <SafeAreaView style={styles.mainContainer}>
 
-            {
-                (yahooData.size === stocksData.size) ?
-                    <>
-                        <MainInfo {...{ stocksData, yahooData }} />
+            <MainInfo />
 
-                        <StockList {...{ stocksData, yahooData }} />
-                    </>
+            {
+                (isStocksDataReady) ?
+                    <StockList />
                     :
                     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
                         <Text>Loading Data</Text>

--- a/pwa/src/pages/Login/index.tsx
+++ b/pwa/src/pages/Login/index.tsx
@@ -10,11 +10,12 @@ import API from '../../services/api'
 import * as Yahoo from '../../services/yahooFinance/stockInfo'
 import DataContext from '../../store/dataContext'
 
+
 const Login = () => {
     const [username, setUsername] = useState('')
     const [password, setPassword] = useState('')
 
-    const { state, dispatch } = useContext(DataContext)
+    const { dispatch } = useContext(DataContext)
 
     const navigation = useNavigation()
 
@@ -24,11 +25,11 @@ const Login = () => {
         const stocks = await API.getStocksData()
         dispatch({ type: 'SET_STOCKS', payload: stocks })
 
+        navigation.navigate('Dashboard')
+
         const tickers = Array.from(stocks.keys())
         const yahooStocks = await Yahoo.getStockInfo(tickers)
         dispatch({ type: 'SET_YAHOO', payload: yahooStocks })
-
-        navigation.navigate('Dashboard')
     }
 
     return (

--- a/pwa/src/pages/NewTransaction/index.tsx
+++ b/pwa/src/pages/NewTransaction/index.tsx
@@ -37,11 +37,11 @@ const NewTransaction = () => {
         const stocks = await API.getStocksData()
         dispatch({ type: 'SET_STOCKS', payload: stocks })
 
+        navigation.navigate('Dashboard')
+
         const tickers = Array.from(stocks.keys())
         const yahooStocks = await Yahoo.getStockInfo(tickers)
         dispatch({ type: 'SET_YAHOO', payload: yahooStocks })
-
-        navigation.navigate('Dashboard')
     }
 
     return (


### PR DESCRIPTION
Navigating to `Dashboard` from `Login` or `NewTransaction` in a regular flux should look like:

- `Login -> Dashboard`: upon authenticated on login request, load backend data, load Yahoo data, and then finally navigate to `Dashboard` when all data is loaded;

- `NewTransaction -> Dashboard`: after successfully creating a new transaction, the backend data is then reloaded into app state and the same is done to Yahoo data before navigating back to `Dashboard`;

The main concern of this PR is to change both of these navigation flux actions to load only the backend data before navigating to `Dashboard`. That way, whenever the screen gets rendered, there will not be Yahoo data appropriately updated to the Backend stock list. To handle that, the screen should present placeholders where said data is supposed to be rendered until it gets properly updated and ready to render on screen.

This will reduce the loading time that the user has to wait before they can see their dashboard, hence giving them a better experience while using the app.