### PR TITLE
Backend Validation Changes

### DIFF
--- a/server/server/models/stock.py
+++ b/server/server/models/stock.py
@@ -11,18 +11,9 @@ class Stock(BaseModel):
     average_bought_price: float
 
     @validator('ticker')
-    def uppercase_any_ticker(cls, value: str):
-        return value.upper()
+    def uppercase_ticker(cls, value: str):
+        return value if value.isupper() else value.upper()
 
 
 class StocksResponse(BaseModel):
     stocks: Dict[str, Stock]
-    total_applied: float = None
-
-    @validator('total_applied', always=True)
-    def calculate_applied(cls, value, values, **kwargs):
-        stocks = values['stocks']
-        return sum(
-            stock.currently_owned_shares * stock.average_bought_price
-            for stock in stocks.values()
-        )

--- a/server/server/models/transaction.py
+++ b/server/server/models/transaction.py
@@ -9,12 +9,20 @@ class Transaction(BaseModel):
     quantity: int
     total_value: float
 
-    timestamp: int = datetime.utcnow().timestamp()
+    timestamp: int = None
     average_price: float = None
 
+    @validator('ticker', always=True)
+    def uppercase_ticker(cls, value: str, **kwargs):
+        return value if value.isupper() else value.upper()
+
+    @validator('timestamp', always=True)
+    def snap_current_time(cls, value: int, **kwargs):
+        return value or datetime.utcnow().timestamp()
+
     @validator('average_price', always=True)
-    def calculate_average_price(cls, value, values, **kwargs):
-        return values['total_value'] / values['quantity']
+    def calculate_average_price(cls, value: float, values: dict, **kwargs):
+        return value or values.get('total_value') / values.get('quantity')
 
 
 class TransactionHistory(BaseModel):


### PR DESCRIPTION
Solving a problem where the created timestamp associated with a created transaction would register only the time when the server were started, not the current time when the transaction was created, which is the indended behavior. This bug caused all transactions to be created at the same exact time per development server session startup, since the function that would return the timestamp was being executed right when the server was initialized.

To address that, the `Transaction` `pydantic` model was changed to create a timestamp for the current exact time it was created in case it is not passed by the request.

Along with these changes, other validation minor changes were made.