### PR TITLE
Centralize NewTransaction

### DIFF
--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -6067,6 +6067,14 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.9.0.tgz",
       "integrity": "sha512-5MaiUD6HA3nzY3JbVI8l3V7pKedtxQF3d8qktTVI0WmWXTI4QzqOU8r8fPVvfKo3MhOXwhWBjr+kQ7DZaIQQeg=="
     },
+    "react-native-switch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-switch/-/react-native-switch-2.0.0.tgz",
+      "integrity": "sha512-Yy8GQBazGBz/VI/Xl2LkyO/4wElnt9hRQ+gY3j/7ZkdfIQftY6IAtvSpU2NEksezUxs4DgNAkcmeDfRO0t2wbg==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-native-web": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.11.7.tgz",

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -4326,6 +4326,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -6004,6 +6009,15 @@
         "fbemitter": "^2.1.1",
         "invariant": "^2.2.4",
         "use-subscription": "^1.0.0"
+      }
+    },
+    "react-native-flip-toggle-button": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-flip-toggle-button/-/react-native-flip-toggle-button-1.0.8.tgz",
+      "integrity": "sha512-yIietb8bDAx+0EdrQ37SKfnGO1IzxgN6/WBZE57FcR/QJH4xXzTvSz4PQyKwBEz9aTxrdZHi95aYHsKZh9ZMOQ==",
+      "requires": {
+        "lodash.capitalize": "^4.2.1",
+        "prop-types": "^15.7.2"
       }
     },
     "react-native-gesture-handler": {

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -19,6 +19,7 @@
     "react-dom": "~16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.1.tar.gz",
     "react-native-action-button": "^2.8.5",
+    "react-native-flip-toggle-button": "^1.0.8",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.1",
     "react-native-paper": "^3.10.1",

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -25,6 +25,7 @@
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",
+    "react-native-switch": "^2.0.0",
     "react-native-web": "~0.11.7"
   },
   "devDependencies": {

--- a/pwa/src/pages/Dashboard/index.tsx
+++ b/pwa/src/pages/Dashboard/index.tsx
@@ -47,7 +47,7 @@ const Dashboard = () => {
             }
 
             <ActionButton
-                onPress={() => navigation.navigate('NewTransaction')}
+                onPress={() => navigation.navigate('NewTransaction', {})}
                 renderIcon={() => <Icon name='plus' size={32} color='#fff' />}
                 buttonColor='rgba(0, 0, 0, 0.8)'
                 hideShadow={Platform.OS === 'web' ? true : false}

--- a/pwa/src/pages/NewTransaction/index.tsx
+++ b/pwa/src/pages/NewTransaction/index.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useCallback } from 'react'
 import { StyleSheet, Text, View, TextInput, TouchableOpacity } from 'react-native'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native'
+import { Switch } from 'react-native-switch'
 
 import Modal, { ModalProvider } from '../../components/Modal'
 import StockPicker from './components/StockPicker'
@@ -12,23 +13,37 @@ import API from '../../services/api'
 import * as Yahoo from '../../services/yahooFinance/stockInfo'
 import DataContext from '../../store/dataContext'
 
+import { AppStackParamList } from '../../routes'
+
 
 const NewTransaction = () => {
-    const [ticker, setTicker] = useState('')
+    const route = useRoute<RouteProp<AppStackParamList, 'NewTransaction'>>()
+    const { initialTicker, initialTransactionType } = route.params
+
+    const [transactionType, setTransactionType] = useState<'IN' | 'OUT'>(initialTransactionType || 'IN')
+
+    const [ticker, setTicker] = useState(initialTicker || '')
     const [quantity, setQuantity] = useState('')
     const [totalValue, setTotalValue] = useState('')
 
     const [showStockPicker, setShowStockPicker] = useState(false)
 
-    const { state, dispatch } = useContext(DataContext)
+    const { dispatch } = useContext(DataContext)
 
     const navigation = useNavigation()
+
+    function toggleTransactionType(current: 'IN' | 'OUT'): 'IN' | 'OUT' {
+        const possibilities = ['IN', 'OUT']
+        const reversed = possibilities.filter(value => value !== current)[0]
+
+        return reversed as 'IN' | 'OUT'
+    }
 
     async function handleSubmitTransaction() {
         const data = {
             ticker,
-            quantity: Number(quantity),
-            total_value: Number(totalValue),
+            quantity: (transactionType === 'OUT' ? -1 : 1) * Number(quantity),
+            total_value: (transactionType === 'OUT' ? -1 : 1) * Number(totalValue),
         }
 
         await API.postNewTransaction(data)
@@ -51,6 +66,22 @@ const NewTransaction = () => {
 
                 <View style={styles.mainContent}>
                     <Text style={styles.title}>New Transaction</Text>
+
+                    <View style={{ marginBottom: 16 }}>
+                        <Switch
+                            value={transactionType === 'IN'}
+                            onValueChange={() => setTransactionType(toggleTransactionType)}
+                            activeText={'In'}
+                            activeTextStyle={{ fontSize: 20, fontWeight: 'bold', color: '#000' }}
+                            backgroundActive={'#fff'}
+                            inActiveText={'Out'}
+                            inactiveTextStyle={{ fontSize: 20, fontWeight: 'bold', color: '#fff' }}
+                            backgroundInactive={'#000'}
+                            circleSize={50}
+                            switchRightPx={2}
+                            switchWidthMultiplier={2.5}
+                        />
+                    </View>
 
                     <TouchableOpacity onPress={() => setShowStockPicker(true)} style={styles.input}>
                         {

--- a/pwa/src/routes.tsx
+++ b/pwa/src/routes.tsx
@@ -15,9 +15,14 @@ export type AppStackParamList = {
     Home: undefined
     Login: undefined
     Register: undefined
-    Dashboard: { loadData: boolean }
-    Detail: { ticker: string }
-    NewTransaction: undefined
+    Dashboard: undefined
+    Detail: {
+        ticker: string
+    }
+    NewTransaction: {
+        initialTicker?: string,
+        initialTransactionType?: 'IN' | 'OUT'
+    }
 }
 
 const AppStack = createStackNavigator<AppStackParamList>()


### PR DESCRIPTION
It is more consistent in terms of _user experience_ to make the `NewTransaction` screen the only place where transactions can be created. 

In #6 and #7 a modal component was created to handle transactions related to the stock for which the `Detail` is presenting. This PR reverts that and transfer all responsibility of transactions to the `NewTransaction` component by passing, through route props, the ticker and a type of transaction.

- `ticker` will render as a suggestion in `NewTransaction` form initial render. 

- `type` will set the internal variables for the component to handle an 'IN' transaction, in case the user wants to increase the number of shares of a stock or an 'OUT' transaction to do the opposite.